### PR TITLE
handle "unusual" chars on paths in file history

### DIFF
--- a/include/git/FileHistory.class.php
+++ b/include/git/FileHistory.class.php
@@ -277,7 +277,7 @@ class GitPHP_FileHistory implements Iterator, GitPHP_Pagination_Interface
 		}
 
 		$args[] = '--';
-		$args[] = $this->path;
+		$args[] = "'{$this->path}'";  // enclose but do not escpapeshellarg becaus of 'äöü' etc
 		$args[] = '|';
 		$args[] = $this->exe->GetBinary();
 		$args[] = '--git-dir=' . escapeshellarg($this->project->GetPath());
@@ -285,7 +285,7 @@ class GitPHP_FileHistory implements Iterator, GitPHP_Pagination_Interface
 		$args[] = '-r';
 		$args[] = '--stdin';
 		$args[] = '--';
-		$args[] = $this->path;
+		$args[] = "'{$this->path}'";
 		
 		$historylines = explode("\n", $this->exe->Execute($this->project->GetPath(), GIT_REV_LIST, $args));
 

--- a/include/git/tree/Tree.class.php
+++ b/include/git/tree/Tree.class.php
@@ -226,6 +226,43 @@ class GitPHP_Tree extends GitPHP_FilesystemObject implements GitPHP_Observable_I
 			return $this->treePaths[$path];
 		}
 
+		// Second try with unslashed names
+		// This is a real ugly hack, but it works for me.
+		// Git adds c style slashes to paths with special characters
+		// and also adds leading and trailing double quotes to the path name
+		// to identify such c style encoded paths.
+		// So the reported path from git does not match the path from gitphp.
+		// Alternatives would be:
+		// 1) git -z
+		//    but I do not know how to add this parameter only here
+		//    and I do not know how to handle the response properly.
+		// 2) use php addcslashes ?
+		//    but I do not know which characters to escape to
+		//    be in sync with git. It is easier to remove c slashes and
+		//    work the reverse route.
+
+		foreach ($this->blobPaths as $key => $hash) {
+
+			if (substr($key, 0, 1) == '"' && substr($key, -1) == '"') {
+				$key = substr($key, 1, -1);
+			}
+			$key = stripcslashes($key);
+			if ($key == $path) {
+				return $hash;
+			}
+		}  // eo blob paths
+
+		foreach ($this->treePaths as $key => $hash) {
+
+			if (substr($key, 0, 1) == '"' && substr($key, -1) == '"') {
+				$key = substr($key, 1, -1);
+			}
+			$key = stripcslashes($key);
+			if ($key == $path) {
+				return $hash;
+			}
+		}  // eo tree paths
+
 		return '';
 	}
 


### PR DESCRIPTION
1) The change in the Tree class is code thats ugly but works.
It was necessary because "git ls-tree" in GitPHP_Tree::ReadHashPaths() returns a path like
[Formulare/Archäologie + Restauration/Einsatzbericht Werkstätten.odt]
as
["Formulare/Arch\303\244ologie + Restauration/Einsatzbericht Werkst\303\244tten.odt"]

2) The change in the FileHistory class is simple to keep path names with spaces together when deliver as parameter to the shell

Feel free to change as you like