### PR TITLE
Fix for spaces in filenames in FileHIstory

### DIFF
--- a/include/git/FileHistory.class.php
+++ b/include/git/FileHistory.class.php
@@ -277,7 +277,7 @@ class GitPHP_FileHistory implements Iterator, GitPHP_Pagination_Interface
 		}
 
 		$args[] = '--';
-		$args[] = $this->path;
+		$args[] = escapeshellarg($this->path);
 		$args[] = '|';
 		$args[] = $this->exe->GetBinary();
 		$args[] = '--git-dir=' . escapeshellarg($this->project->GetPath());
@@ -285,7 +285,7 @@ class GitPHP_FileHistory implements Iterator, GitPHP_Pagination_Interface
 		$args[] = '-r';
 		$args[] = '--stdin';
 		$args[] = '--';
-		$args[] = $this->path;
+		$args[] = escapeshellarg($this->path);
 		
 		$historylines = explode("\n", $this->exe->Execute($this->project->GetPath(), GIT_REV_LIST, $args));
 


### PR DESCRIPTION
The git history for files containing spaces appears blank unless the 
space is either escaped or quoted.