### PR TITLE
Security vulnerability: Users can execute shell commands

### DIFF
--- a/include/controller/Controller_GraphData.class.php
+++ b/include/controller/Controller_GraphData.class.php
@@ -76,7 +76,7 @@ class GitPHP_Controller_GraphData extends GitPHP_ControllerBase
 
 			$data = array();
 
-			$commits = explode("\n", $this->exe->Execute($this->GetProject()->GetPath(), 'rev-list', array('--format=format:"%H %ct"', $head->GetHash())));
+			$commits = explode("\n", $this->exe->Execute($this->GetProject()->GetPath(), 'rev-list', array('--format=format:"%H %ct"', escapeshellarg($head->GetHash()))));
 			foreach ($commits as $commit) {
 				if (preg_match('/^([0-9a-fA-F]{40}) ([0-9]+)$/', $commit, $regs)) {
 					$data[] = array('CommitEpoch' => (int)$regs[2]);
@@ -90,7 +90,7 @@ class GitPHP_Controller_GraphData extends GitPHP_ControllerBase
 			include_once(GITPHP_GESHIDIR . "geshi.php");
 			$geshi = new GeSHi("",'php');
 
-			$files = explode("\n", $this->exe->Execute($this->GetProject()->GetPath(), 'ls-tree', array('-r', '--name-only', $head->GetTree()->GetHash())));
+			$files = explode("\n", $this->exe->Execute($this->GetProject()->GetPath(), 'ls-tree', array('-r', '--name-only', escapeshellarg($head->GetTree()->GetHash()))));
 			foreach ($files as $file) {
 				$filename = GitPHP_Util::BaseName($file);
 				$lang = GitPHP_Util::GeshiFilenameToLanguage($filename);

--- a/include/git/FileBlame.class.php
+++ b/include/git/FileBlame.class.php
@@ -141,9 +141,9 @@ class GitPHP_FileBlame
 		$args = array();
 		$args[] = '-s';
 		$args[] = '-l';
-		$args[] = $this->commitHash;
+		$args[] = escapeshellarg($this->commitHash);
 		$args[] = '--';
-		$args[] = $this->path;
+		$args[] = escapeshellarg($this->path);
 
 		$blamelines = explode("\n", $this->exe->Execute($this->project->GetPath(), GIT_BLAME, $args));
 

--- a/include/git/FileHistory.class.php
+++ b/include/git/FileHistory.class.php
@@ -265,19 +265,19 @@ class GitPHP_FileHistory implements Iterator, GitPHP_Pagination_Interface
 
 		if ($canSkip) {
 			if ($this->limit > 0) {
-				$args[] = '--max-count=' . $this->limit;
+				$args[] = '--max-count=' . escapeshellarg($this->limit);
 			}
 			if ($this->skip > 0) {
-				$args[] = '--skip=' . $this->skip;
+				$args[] = '--skip=' . escapeshellarg($this->skip);
 			}
 		} else {
 			if ($this->limit > 0) {
-				$args[] = '--max-count=' . ($this->limit + $this->skip);
+				$args[] = '--max-count=' . escapeshellarg($this->limit + $this->skip);
 			}
 		}
 
 		$args[] = '--';
-		$args[] = $this->path;
+		$args[] = escapeshellarg($this->path);
 		$args[] = '|';
 		$args[] = $this->exe->GetBinary();
 		$args[] = '--git-dir=' . escapeshellarg($this->project->GetPath());
@@ -285,7 +285,7 @@ class GitPHP_FileHistory implements Iterator, GitPHP_Pagination_Interface
 		$args[] = '-r';
 		$args[] = '--stdin';
 		$args[] = '--';
-		$args[] = $this->path;
+		$args[] = escapeshellarg($this->path);
 		
 		$historylines = explode("\n", $this->exe->Execute($this->project->GetPath(), GIT_REV_LIST, $args));
 

--- a/include/git/FileSearch.class.php
+++ b/include/git/FileSearch.class.php
@@ -382,8 +382,8 @@ class GitPHP_FileSearch implements Iterator, GitPHP_Pagination_Interface
 		$args[] = '--ignore-case';
 		$args[] = '-n';
 		$args[] = '-e';
-		$args[] = '"' . addslashes($this->search) . '"';
-		$args[] = $this->treeHash;
+		$args[] = escapeshellarg($this->search);
+		$args[] = escapeshellarg($this->treeHash);
 
 		$lines = explode("\n", $this->exe->Execute($this->project->GetPath(), GIT_GREP, $args));
 

--- a/include/git/TreeDiff.class.php
+++ b/include/git/TreeDiff.class.php
@@ -121,9 +121,9 @@ class GitPHP_TreeDiff implements Iterator
 		if (empty($this->fromHash))
 			$args[] = '--root';
 		else
-			$args[] = $this->fromHash;
+			$args[] = escapeshellarg($this->fromHash);
 
-		$args[] = $this->toHash;
+		$args[] = escapeshellarg($this->toHash);
 
 		$diffTreeLines = explode("\n", $this->exe->Execute($this->GetProject()->GetPath(), GIT_DIFF_TREE, $args));
 		foreach ($diffTreeLines as $line) {

--- a/include/git/blob/BlobLoad_Base.class.php
+++ b/include/git/blob/BlobLoad_Base.class.php
@@ -42,7 +42,7 @@ abstract class GitPHP_BlobLoad_Base implements GitPHP_BlobLoadStrategy_Interface
 
 		$args = array();
 		$args[] = '-s';
-		$args[] = $blob->GetHash();
+		$args[] = escapeshellarg($blob->GetHash());
 
 		return $this->exe->Execute($blob->GetProject()->GetPath(), GIT_CAT_FILE, $args);
 	}

--- a/include/git/commit/CommitLoad_Base.class.php
+++ b/include/git/commit/CommitLoad_Base.class.php
@@ -42,7 +42,7 @@ abstract class GitPHP_CommitLoad_Base implements GitPHP_CommitLoadStrategy_Inter
 
 		$args = array();
 		$args[] = '--tags';
-		$args[] = $commit->GetHash();
+		$args[] = escapeshellarg($commit->GetHash());
 		$revs = explode("\n", $this->exe->Execute($commit->GetProject()->GetPath(), GIT_NAME_REV, $args));
 
 		foreach ($revs as $revline) {

--- a/include/git/project/ProjectLoad_Git.class.php
+++ b/include/git/project/ProjectLoad_Git.class.php
@@ -89,7 +89,7 @@ class GitPHP_ProjectLoad_Git implements GitPHP_ProjectLoadStrategy_Interface
 		$args = array();
 		$args[] = '-1';
 		$args[] = '--format=format:%H';
-		$args[] = $abbrevHash;
+		$args[] = escapeshellarg($abbrevHash);
 
 		$fullData = explode("\n", $this->exe->Execute($project->GetPath(), GIT_REV_LIST, $args));
 		if (empty($fullData[0])) {
@@ -125,7 +125,7 @@ class GitPHP_ProjectLoad_Git implements GitPHP_ProjectLoadStrategy_Interface
 		$args = array();
 		$args[] = '-1';
 		$args[] = '--format=format:%h';
-		$args[] = $hash;
+		$args[] = escapeshellarg($hash);
 
 		$abbrevData = explode("\n", $this->exe->Execute($project->GetPath(), GIT_REV_LIST, $args));
 		if (empty($abbrevData[0])) {

--- a/include/git/reflist/RefListLoad_Git.class.php
+++ b/include/git/reflist/RefListLoad_Git.class.php
@@ -45,7 +45,7 @@ abstract class GitPHP_RefListLoad_Git
 			return;
 
 		$args = array();
-		$args[] = '--' . $type;
+		$args[] = '--' . escapeshellarg($type);
 		$args[] = '--dereference';
 		$ret = $this->exe->Execute($refList->GetProject()->GetPath(), GIT_SHOW_REF, $args);
 
@@ -86,17 +86,17 @@ abstract class GitPHP_RefListLoad_Git
 			return null;
 
 		$args = array();
-		$args[] = '--sort=' . $order;
+		$args[] = '--sort=' . escapeshellarg($order);
 		$args[] = '--format="%(refname)"';
 		if ($count > 0) {
 			if ($skip > 0) {
-				$args[] = '--count=' . ($count + $skip);
+				$args[] = '--count=' . escapeshellarg($count + $skip);
 			} else {
-				$args[] = '--count=' . $count;
+				$args[] = '--count=' . escapeshellarg($count);
 			}
 		}
 		$args[] = '--';
-		$args[] = 'refs/' . $type;
+		$args[] = escapeshellarg('refs/' . $type);
 		$ret = $this->exe->Execute($refList->GetProject()->GetPath(), GIT_FOR_EACH_REF, $args);
 
 		$lines = explode("\n", $ret);

--- a/include/git/revlist/RevList_Git.class.php
+++ b/include/git/revlist/RevList_Git.class.php
@@ -52,14 +52,14 @@ class GitPHP_RevList_Git
 
 		if ($canSkip) {
 			if ($count > 0) {
-				$extraargs[] = '--max-count=' . $count;
+				$extraargs[] = '--max-count=' . escapeshellarg($count);
 			}
 			if ($skip > 0) {
-				$extraargs[] = '--skip=' . $skip;
+				$extraargs[] = '--skip=' . escapeshellarg($skip);
 			}
 		} else {
 			if ($count > 0) {
-				$extraargs[] = '--max-count=' . ($count + $skip);
+				$extraargs[] = '--max-count=' . escapeshellarg($count + $skip);
 			}
 		}
 

--- a/include/git/tag/TagLoad_Git.class.php
+++ b/include/git/tag/TagLoad_Git.class.php
@@ -112,7 +112,7 @@ class GitPHP_TagLoad_Git implements GitPHP_TagLoadStrategy_Interface
 			case 'tag':
 				$args = array();
 				$args[] = 'tag';
-				$args[] = $objectHash;
+				$args[] = escapeshellarg($objectHash);
 				$ret = $this->exe->Execute($tag->GetProject()->GetPath(), GIT_CAT_FILE, $args);
 				$lines = explode("\n", $ret);
 				foreach ($lines as $i => $line) {

--- a/include/git/tree/TreeLoad_Base.class.php
+++ b/include/git/tree/TreeLoad_Base.class.php
@@ -47,7 +47,7 @@ abstract class GitPHP_TreeLoad_Base implements GitPHP_TreeLoadStrategy_Interface
 		$args[] = '--full-name';
 		$args[] = '-r';
 		$args[] = '-t';
-		$args[] = $tree->GetHash();
+		$args[] = escapeshellarg($tree->GetHash());
 
 		$lines = explode("\n", $this->exe->Execute($tree->GetProject()->GetPath(), GIT_LS_TREE, $args));
 

--- a/include/git/tree/TreeLoad_Git.class.php
+++ b/include/git/tree/TreeLoad_Git.class.php
@@ -29,7 +29,7 @@ class GitPHP_TreeLoad_Git extends GitPHP_TreeLoad_Base
 		if ($this->exe->CanShowSizeInTree())
 			$args[] = '-l';
 		$args[] = '-t';
-		$args[] = $tree->GetHash();
+		$args[] = escapeshellarg($tree->GetHash());
 		
 		$lines = explode("\n", $this->exe->Execute($tree->GetProject()->GetPath(), GIT_LS_TREE, $args));
 


### PR DESCRIPTION
Shell injections are possible, not trusted arguments are passed directly to `shell_exec()` without being escaped first.

For example, the name of a file in a Git repo can be used to execute shell command through the file history feature.

Arguments are constructed in `FileHistory.class.php` (https://github.com/xiphux/gitphp/blob/master/include/git/FileHistory.class.php#L288) and then passed to `GitPHP_GitExe::Execute` to call `shell_exec()` (https://github.com/xiphux/gitphp/blob/master/include/git/GitExe.class.php#L173).